### PR TITLE
Update copy

### DIFF
--- a/content/titleText.js
+++ b/content/titleText.js
@@ -4,8 +4,8 @@ import TitleTextTooltip from '../components/TitleTextTooltip'
 const tooltipText = 'But even if we say water is great for swimming, we are NOT suggesting that you get in it! This dashboard does not condone unsanctioned swimming and is only an awareness platform. Please don\'t jump in until we have a + POOL!'
 
 export default {
-  introText: <><span>We’re tracking the water in the NYC harbor at Pier 17.</span><span>How is the water today?</span></>,
-  introCta: 'Click here to find out.',
+  introText: <><span>We’re tracking the water in the NYC harbor at Pier 17.</span></>,
+  introCta: 'Click here see the results.',
   bacteriaText: {
     acceptable: <>great for <TitleTextTooltip tooltipText={tooltipText}>swimming</TitleTextTooltip>.</>,
     unacceptablePersist: <>not great for <TitleTextTooltip tooltipText={tooltipText}>swimming</TitleTextTooltip> if levels persist.</>,


### PR DESCRIPTION
We’re no longer showing “Today” data, since the sensors were turned off.

Before:

<img width="400" alt="Screen Shot 2020-06-10 at 5 17 09 PM" src="https://user-images.githubusercontent.com/3090208/84319616-51633680-ab3e-11ea-9e3a-7aab454b5e84.png">

After:

<img width="400" alt="Screen Shot 2020-06-10 at 5 16 51 PM" src="https://user-images.githubusercontent.com/3090208/84319631-5627ea80-ab3e-11ea-8bbc-3d28c6b6652d.png">
