### PR TITLE
refactor: index page improvements

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -9,10 +9,10 @@ import { useSample } from '../hooks/useSamples'
 import PageWrapper, {getPageData} from '../components/PageWrapper'
 import { DATE_UNITS } from '../helpers/constants';
 
-const IndexPage = ({ sources, units, ...samples }) => {
+const IndexPage = ({ sources, units, samples }) => {
   const [tooltipOpen, setTooltipOpen] = useState(false)
   const [tooltipSlug, setTooltipSlug] = useState()
-  const [sample, range, timestamp, setTimestamp] = useSample(samples[DATE_UNITS.YEAR])
+  const [sample, range, timestamp, setTimestamp] = useSample(samples)
   const [pageState, setPageState] = useState(0)
 
   const advanceIntro = () => pageState < 1 && setPageState(pageState + 1)


### PR DESCRIPTION
- Made use of the getStaticProps custom closure function
  - Refactored the getStaticProps functionality to not burden the index page with sampled data meant for different date ranges, that it doesn't use.
  - Index page only needs yearly data points
  - Increased the down sampling of the yearly data for the Index page by 500 points to further increase the page's performance; it doesn't show a graph thus not needing such detailed breakdown. Data page shows more details with less down sampling of 1000 points for each date range