### PR TITLE
feat: added progress bar to dynamic import

### DIFF
--- a/pages/data.js
+++ b/pages/data.js
@@ -2,9 +2,10 @@ import React, { useState } from 'react'
 import dynamic from 'next/dynamic'
 import Tooltip from '../components/Tooltip'
 import PageWrapper, { getPageData } from '../components/PageWrapper';
+import ProgressBar from '../components/ProgressBar';
 
 //dynamically / lazy load import graphs component without server side rendering as chart.js + zoom and pan requires usage of browser window API
-const DynamicGraphs = dynamic(() => import('../components/Graphs'), {ssr: false}) // can now add <ProgressBar /> to the loading prop of the options to simulate loading, if needed.
+const DynamicGraphs = dynamic(() => import('../components/Graphs'), {ssr: false, loading: () => <ProgressBar />}) // simulate loading of the graphs
 
 const DataPage = ({ sources, units, ...samples }) => {
   const [tooltipOpen, setTooltipOpen] = useState(false)


### PR DESCRIPTION
- Added progress bar loading element to the dynamic import of graphs component to simulate loading to the users.
  - can be  used now as we are not using a top level loading bar for getting data on app mount, anymore.