### PR TITLE
feat: turning off ISR(incremental static regeneration)

### DIFF
--- a/components/PageWrapper.js
+++ b/components/PageWrapper.js
@@ -77,8 +77,7 @@ export const getPageData = (page) => {
             : { ...dsSamples }),
           //samples: data.samples // EX: non-sampled data
         },
-        revalidate: false
-          //60 * 15, // revalidate every 15 minutes <- provides Incremental Static Regeneration
+        revalidate: false //our backend lambda handles site data updates. We no longer need to revalidate
       };
     } catch (err) {
       console.log(err);

--- a/components/PageWrapper.js
+++ b/components/PageWrapper.js
@@ -77,7 +77,8 @@ export const getPageData = (page) => {
             : { ...dsSamples }),
           //samples: data.samples // EX: non-sampled data
         },
-        revalidate: 60 * 15, // revalidate every 15 minutes <- provides Incremental Static Regeneration
+        revalidate: false
+          //60 * 15, // revalidate every 15 minutes <- provides Incremental Static Regeneration
       };
     } catch (err) {
       console.log(err);


### PR DESCRIPTION
Once  our lambda site deployer over in AWS started executing every 15 minutes, we really didn't need to revalidate on a 15 minute time intervals anymore, as that would be doing the same exact thing our lambda site deployer is doing. To that end, this PR turns that revalidation off.

This should also cut down on our cache writes in vercel:

![Screenshot 2024-10-09 at 8 44 34 AM](https://github.com/user-attachments/assets/24ecb877-d65e-4dfb-91e3-3942523a9854)

___

Ultimately, since we're upgraded to Next.js v13, we could potentially explore a conversion to `on demand` revalidation. This would remove the necessity to have to redeploy; it would however, require a few changes to make it work.

- Creating an api route module under the `pages/api` directory that can handle a revalidation request and only revalidate if the `secret` matches what was passed in.
   - the API would handle the revalidation for the 2 pages we need data for:
      - index page (main page)
      - data page (where the graphs are shown)

- Updating our [site deployer lambda](https://github.com/reaktor/pluspool-serverless/blob/main/functions/site-deployer/index.js) on our backend to hit the revalidation endpoint of our Next.js app instead of the redeploy hook.


The API endpoint would look roughly something like this:

```
export default async function handler(req, res) {
  if (req.query.secret !== process.env.REVALIDATE_SECRET) {
    return res.status(401).json({ message: 'Invalid request.' });
  }

  try {
    await res.revalidate('/');
    await res.revalidate('/data');
    
    return res.json({ revalidated: true });
  } catch (err) {
    console.error(err)
    return res.status(500).json({ message: 'Server error' });
  }
```

___

### **Switching to on demand revalidation would bring the usage back against Vercel's data cache write and its included soft limits, whereas we're allowed 6000 deployments per day on our Vercel account and never get even close to that (we do 96). The usage cost with redeployment hook is included compared to potential increase due to static regeneration limit hits.**