### PR TITLE
Typo: Fixed Keanu's name

### DIFF
--- a/content/tooltip.js
+++ b/content/tooltip.js
@@ -30,7 +30,7 @@ export default {
     </>
   ),
   speed: (
-    <p>Speed affects how fast (or how slow!) an area of water changes. Not related to the Keanue Reeves film(s)!</p>
+    <p>Speed affects how fast (or how slow!) an area of water changes. Not related to the Keanu Reeves film(s)!</p>
   ),
   direction: (
     <>


### PR DESCRIPTION
Keanu Reeves' name is misspelled on the "Speed" tooltip:

<img width="804" alt="typo" src="https://github.com/user-attachments/assets/8617d885-05ec-4989-b936-60fb28737d8e">

This change fixes the typo.